### PR TITLE
Fix #10 'Seasons' tab in the nav

### DIFF
--- a/the-enchiridion/src/components/GodProvider.js
+++ b/the-enchiridion/src/components/GodProvider.js
@@ -1,12 +1,15 @@
 import { AuthProvider } from "./auth/AuthProvider";
 import { PlaylistProvider } from "./playlists/PlaylistProvider";
+import { SeasonProvider } from "./seasons/SeasonProvider";
 
 export const GodProvider = (props) => {
   return (
     <>
       <AuthProvider>
         <PlaylistProvider>
-          {props.children}
+          <SeasonProvider>
+            {props.children}
+          </SeasonProvider>
         </PlaylistProvider>
       </AuthProvider>
     </>

--- a/the-enchiridion/src/components/seasons/SeasonProvider.js
+++ b/the-enchiridion/src/components/seasons/SeasonProvider.js
@@ -1,0 +1,24 @@
+import { createContext, useState } from "react";
+
+export const SeasonContext = createContext();
+
+export const SeasonProvider = (props) => {
+    const [seasons, setSeasons] = useState([]);
+    const url = "http://localhost:8000";
+
+    const getAllSeasons = () => {
+        return fetch(`${url}/seasons`).then((res) => res.json());
+    }
+
+    const getSeasonById = (id) => {
+        return fetch(`${url}/seasons/${id}`).then((res) => res.json());
+    }
+
+    return (
+        <SeasonContext.Provider value={{
+            seasons, setSeasons, getAllSeasons, getSeasonById
+        }}>
+            {props.children}
+        </SeasonContext.Provider>
+    );
+};

--- a/the-enchiridion/src/components/seasons/Seasons.js
+++ b/the-enchiridion/src/components/seasons/Seasons.js
@@ -1,0 +1,38 @@
+import { useContext, useEffect, useState } from "react";
+import { SeasonContext } from "./SeasonProvider";
+import { Link } from "react-router-dom";
+
+export const Seasons = () => {
+    const { seasons, setSeasons, getAllSeasons } = useContext(SeasonContext);
+    const [isLoading, setIsLoading] = useState(true);
+    const imgURL = "https://www.themoviedb.org/t/p/w260_and_h390_bestv2";
+
+    useEffect(() => {
+        getAllSeasons().then((res) => setSeasons(res)).then(() => setIsLoading(false));
+    }, []);
+
+    if (isLoading) {
+        return <h1>Loading...</h1>;
+    } else if (seasons.length === 0) {
+        return <h1>No seasons found</h1>;
+    }
+    return (
+        <>
+          <h1 className="mt-5 text-3xl text-center">Seasons</h1>
+          <div className="flex flex-wrap justify-evenly">
+            {seasons.map((season) => {
+              return (
+                <div key={`season--${season.id}`} className="pop-out flex-col w-1/6 mx-2 my-5 border-2 border-none rounded-lg shadow-md p-4 backdrop-blur-sm cursor-pointer">
+                  <Link to={`season/${season.id}`}>
+                    <div>
+                        <img className="rounded-lg" src={`${imgURL}${season.poster_path}`} alt={season.name} />
+                    </div>
+                    <div className="pt-4 text-xl text-center">{season.name}</div>
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+        </>
+    );
+};

--- a/the-enchiridion/src/components/views/ApplicationViews.js
+++ b/the-enchiridion/src/components/views/ApplicationViews.js
@@ -1,6 +1,7 @@
 import { Outlet, Route, Routes } from "react-router-dom";
 import { Home } from "../home/Home";
 import { Playlists } from "../playlists/Playlists";
+import { Seasons } from "../seasons/Seasons";
 
 export const ApplicationViews = () => {
     const localEnchiridionUser = localStorage.getItem("enchiridion_user");
@@ -13,6 +14,7 @@ export const ApplicationViews = () => {
           <Route path="/" element={<Home />} />
           <Route path="/playlists" element={<Playlists />} />
           <Route path="/playlists/:section" element={<Playlists />} />
+          <Route path="/seasons" element={<Seasons />} />
         </Route>
       </Routes>
     </>


### PR DESCRIPTION
# Fix list of seasons linked in navigation bar

Allows visitors or registered users to view all seasons whether they're logged in or not via the 'Seasons' tab in the navigation bar
Adds a new SeasonProvider with appropriate server side queries
Supports the `/seasons` link in `ApplicationViews.js`
Adds the new provider wrapper in the `GodProvider.js`

<!-- Add in the issue number here-->
Fixes #10 'Seasons' tab in the nav

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README
**Also requires pulling the most recent `main` branch for the [enchiridion-server repo](https://github.com/macleann/enchiridion-server) as well**

```
git fetch origin nm-list-of-seasons
git checkout nm-list-of-seasons
npm start
```

- [ ] Go to `http://localhost:3000/playlists`
- [ ] Click 'Seasons' in the navigation bar
- [ ] You should be able to see all seasons of Adventure Time

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
