### PR TITLE
Fix #11 Add a 'Season Detail' page

### DIFF
--- a/the-enchiridion/src/components/seasons/SeasonDetail.js
+++ b/the-enchiridion/src/components/seasons/SeasonDetail.js
@@ -1,0 +1,46 @@
+import { useContext, useEffect, useState } from "react"
+import { Link, useParams } from "react-router-dom"
+import { SeasonContext } from "./SeasonProvider"
+
+export const SeasonDetail = () => {
+    const { seasonId } = useParams()
+    const { getSeasonById } = useContext(SeasonContext)
+    const [season, setSeason] = useState({})
+    const [isLoading, setIsLoading] = useState(true)
+    const seasonimgURL = "https://www.themoviedb.org/t/p/w260_and_h390_bestv2"
+    const episodeimgURL = "https://www.themoviedb.org/t/p/w454_and_h254_bestv2"
+
+    useEffect(() => {
+        getSeasonById(seasonId).then((res) => setSeason(res)).then(() => setIsLoading(false))
+    }, [])
+
+    if (isLoading) {
+        return <h1>Loading...</h1>
+    } else if (season.detail === "Not found.") {
+        return <h1>Season not found</h1>
+    }
+    return (
+        <>
+            <h2 className="text-3xl text-center mb-6">{season.name}</h2>
+            <div className="flex justify-center">
+                <div className="w-1/2 justify-end pr-4 pl-8"><img src={`${seasonimgURL}${season.poster_path}`}/></div>
+                <div className="w-1/2 justify-start pl-4 pr-8">{season.overview}</div>
+            </div>
+            <div>
+                {season.episodes.map((episode) => {
+                return (
+                    <div key={`episode--${episode.id}`} className="flex justify-center">
+                        <div className="w-1/2 justify-end pr-4 pl-8"><img src={`${episodeimgURL}${episode.still_path}`}/></div>
+                        <div className="w-1/2 justify-start pl-4 pr-8">
+                            <Link to={`/episodes/${episode.episode_number}`}>
+                                <h3 className="text-2xl">{episode.name}</h3>
+                            </Link>
+                            <p>{episode.overview}</p>
+                        </div>
+                    </div>
+                );
+                })}
+            </div>
+        </>
+    )
+}

--- a/the-enchiridion/src/components/seasons/SeasonDetail.js
+++ b/the-enchiridion/src/components/seasons/SeasonDetail.js
@@ -3,15 +3,15 @@ import { Link, useParams } from "react-router-dom"
 import { SeasonContext } from "./SeasonProvider"
 
 export const SeasonDetail = () => {
-    const { seasonId } = useParams()
-    const { getSeasonById } = useContext(SeasonContext)
+    const { seasonNumber } = useParams()
+    const { getSeasonBySeasonNumber } = useContext(SeasonContext)
     const [season, setSeason] = useState({})
     const [isLoading, setIsLoading] = useState(true)
     const seasonimgURL = "https://www.themoviedb.org/t/p/w260_and_h390_bestv2"
     const episodeimgURL = "https://www.themoviedb.org/t/p/w454_and_h254_bestv2"
 
     useEffect(() => {
-        getSeasonById(seasonId).then((res) => setSeason(res)).then(() => setIsLoading(false))
+        getSeasonBySeasonNumber(seasonNumber).then((res) => setSeason(res)).then(() => setIsLoading(false))
     }, [])
 
     if (isLoading) {

--- a/the-enchiridion/src/components/seasons/SeasonProvider.js
+++ b/the-enchiridion/src/components/seasons/SeasonProvider.js
@@ -10,8 +10,8 @@ export const SeasonProvider = (props) => {
         return fetch(`${url}/seasons`).then((res) => res.json());
     }
 
-    const getSeasonById = (id) => {
-        return fetch(`${url}/seasons/${id}`).then((res) => res.json());
+    const getSeasonById = (season_number) => {
+        return fetch(`${url}/seasons/${season_number}`).then((res) => res.json());
     }
 
     return (

--- a/the-enchiridion/src/components/seasons/SeasonProvider.js
+++ b/the-enchiridion/src/components/seasons/SeasonProvider.js
@@ -10,13 +10,13 @@ export const SeasonProvider = (props) => {
         return fetch(`${url}/seasons`).then((res) => res.json());
     }
 
-    const getSeasonById = (season_number) => {
+    const getSeasonBySeasonNumber = (season_number) => {
         return fetch(`${url}/seasons/${season_number}`).then((res) => res.json());
     }
 
     return (
         <SeasonContext.Provider value={{
-            seasons, setSeasons, getAllSeasons, getSeasonById
+            seasons, setSeasons, getAllSeasons, getSeasonBySeasonNumber
         }}>
             {props.children}
         </SeasonContext.Provider>

--- a/the-enchiridion/src/components/seasons/Seasons.js
+++ b/the-enchiridion/src/components/seasons/Seasons.js
@@ -23,7 +23,7 @@ export const Seasons = () => {
             {seasons.map((season) => {
               return (
                 <div key={`season--${season.id}`} className="pop-out flex-col w-1/6 mx-2 my-5 border-2 border-none rounded-lg shadow-md p-4 backdrop-blur-sm cursor-pointer">
-                  <Link to={`season/${season.id}`}>
+                  <Link to={`${season.season_number}`}>
                     <div>
                         <img className="rounded-lg" src={`${imgURL}${season.poster_path}`} alt={season.name} />
                     </div>

--- a/the-enchiridion/src/components/views/ApplicationViews.js
+++ b/the-enchiridion/src/components/views/ApplicationViews.js
@@ -2,6 +2,7 @@ import { Outlet, Route, Routes } from "react-router-dom";
 import { Home } from "../home/Home";
 import { Playlists } from "../playlists/Playlists";
 import { Seasons } from "../seasons/Seasons";
+import { SeasonDetail } from "../seasons/SeasonDetail";
 
 export const ApplicationViews = () => {
     const localEnchiridionUser = localStorage.getItem("enchiridion_user");
@@ -15,6 +16,7 @@ export const ApplicationViews = () => {
           <Route path="/playlists" element={<Playlists />} />
           <Route path="/playlists/:section" element={<Playlists />} />
           <Route path="/seasons" element={<Seasons />} />
+          <Route path="/seasons/:seasonId" element={<SeasonDetail />} />
         </Route>
       </Routes>
     </>

--- a/the-enchiridion/src/components/views/ApplicationViews.js
+++ b/the-enchiridion/src/components/views/ApplicationViews.js
@@ -16,7 +16,7 @@ export const ApplicationViews = () => {
           <Route path="/playlists" element={<Playlists />} />
           <Route path="/playlists/:section" element={<Playlists />} />
           <Route path="/seasons" element={<Seasons />} />
-          <Route path="/seasons/:seasonId" element={<SeasonDetail />} />
+          <Route path="/seasons/:seasonNumber" element={<SeasonDetail />} />
         </Route>
       </Routes>
     </>


### PR DESCRIPTION
# Fix the link to season detail pages from list of seasons page

Allows visitors or registered users to view a specific season that shows a list of episodes in that season
Changes the hastily made getSeasonById fetch call to get by season_number parameter instead of by id in `SeasonProvider.js`
Changes the `season.id` to `season.season_number` for navigation link in `Seasons.js`
Supports the `/seasons/:season_number` link in `ApplicationViews.js`

<!-- Add in the issue number here-->
Fixes #11 Add a 'Season Detail' page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-season-detail
git checkout nm-season-detail
npm start
```

- [ ] Go to `http://localhost:3000/playlists`
- [ ] Click 'Seasons' in the navigation bar
- [ ] Select any season
- [ ] You should be able to see any given season and the episodes it contains

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
