### PR TITLE
Fix #12 Add an 'Episode Detail' page

### DIFF
--- a/the-enchiridion/src/components/GodProvider.js
+++ b/the-enchiridion/src/components/GodProvider.js
@@ -1,4 +1,5 @@
 import { AuthProvider } from "./auth/AuthProvider";
+import { EpisodeProvider } from "./episodes/EpisodeProvider";
 import { PlaylistProvider } from "./playlists/PlaylistProvider";
 import { SeasonProvider } from "./seasons/SeasonProvider";
 
@@ -8,7 +9,9 @@ export const GodProvider = (props) => {
       <AuthProvider>
         <PlaylistProvider>
           <SeasonProvider>
-            {props.children}
+            <EpisodeProvider>
+              {props.children}
+            </EpisodeProvider>
           </SeasonProvider>
         </PlaylistProvider>
       </AuthProvider>

--- a/the-enchiridion/src/components/episodes/EpisodeDetail.js
+++ b/the-enchiridion/src/components/episodes/EpisodeDetail.js
@@ -1,0 +1,40 @@
+import { useContext, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { EpisodeContext } from "./EpisodeProvider";
+
+
+export const EpisodeDetail = () => {
+    const { episode, setEpisode, getEpisodeByNumberFromTMDB, getEpisodeByIdFromLocalDB } = useContext(EpisodeContext);
+    const { episodeId, seasonNumber, episodeNumber } = useParams();
+    const [isLoading, setIsLoading] = useState(true);
+    const episodeimgURL = "https://www.themoviedb.org/t/p/w454_and_h254_bestv2"
+
+    useEffect(() => {
+        if (episodeId) {
+            getEpisodeByIdFromLocalDB(episodeId).then((res) => setEpisode(res)).then(() => setIsLoading(false));
+        } else if (seasonNumber && episodeNumber) {
+            getEpisodeByNumberFromTMDB(seasonNumber, episodeNumber).then((res) => setEpisode(res)).then(() => setIsLoading(false));
+        }
+    }, []);
+
+    if (isLoading) {
+        return <h1>Loading...</h1>;
+    } else if (episode.error) {
+        console.log(episode.error)
+        return <h1>Episode not found</h1>;
+    }
+    return <>
+        <div>
+            <h2 className="mt-4 text-3xl text-center">{episode.name}</h2>
+            <div className="flex justify-center mt-4">
+                <div className="w-1/2 pr-4 pl-8"><img src={`${episodeimgURL}${episode.still_path}`}/></div>
+                <div className="w-1/2 flex-col justify-start pl-4 pr-8">
+                    <div>{episode.overview}</div>
+                    <div className="mt-4">Air Date: {episode.air_date}</div>
+                    <div className="mt-4">Runtime: {episode.runtime} minutes</div>
+                </div>
+            </div>
+        </div>
+        
+    </>
+}

--- a/the-enchiridion/src/components/episodes/EpisodeProvider.js
+++ b/the-enchiridion/src/components/episodes/EpisodeProvider.js
@@ -1,0 +1,24 @@
+import { createContext, useState } from "react";
+
+export const EpisodeContext = createContext();
+
+export const EpisodeProvider = (props) => {
+    const [episode, setEpisode] = useState({});
+    const url = "http://localhost:8000";
+
+    const getEpisodeByNumberFromTMDB = (seasonNumber, episodeNumber) => {
+        return fetch(`${url}/episodes/tmdb/${seasonNumber}/${episodeNumber}`).then((res) => res.json());
+    }
+
+    const getEpisodeByIdFromLocalDB = (episodeId) => {
+        return fetch(`${url}/episodes/${episodeId}`).then((res) => res.json());
+    }
+
+    return (
+        <EpisodeContext.Provider value={{
+            episode, setEpisode, getEpisodeByNumberFromTMDB, getEpisodeByIdFromLocalDB
+        }}>
+            {props.children}
+        </EpisodeContext.Provider>
+    );
+}

--- a/the-enchiridion/src/components/seasons/SeasonDetail.js
+++ b/the-enchiridion/src/components/seasons/SeasonDetail.js
@@ -32,7 +32,7 @@ export const SeasonDetail = () => {
                     <div key={`episode--${episode.id}`} className="flex justify-center">
                         <div className="w-1/2 justify-end pr-4 pl-8"><img src={`${episodeimgURL}${episode.still_path}`}/></div>
                         <div className="w-1/2 justify-start pl-4 pr-8">
-                            <Link to={`/episodes/${episode.episode_number}`}>
+                            <Link to={`episodes/${episode.episode_number}`}>
                                 <h3 className="text-2xl">{episode.name}</h3>
                             </Link>
                             <p>{episode.overview}</p>

--- a/the-enchiridion/src/components/views/ApplicationViews.js
+++ b/the-enchiridion/src/components/views/ApplicationViews.js
@@ -3,6 +3,7 @@ import { Home } from "../home/Home";
 import { Playlists } from "../playlists/Playlists";
 import { Seasons } from "../seasons/Seasons";
 import { SeasonDetail } from "../seasons/SeasonDetail";
+import { EpisodeDetail } from "../episodes/EpisodeDetail";
 
 export const ApplicationViews = () => {
     const localEnchiridionUser = localStorage.getItem("enchiridion_user");
@@ -15,8 +16,10 @@ export const ApplicationViews = () => {
           <Route path="/" element={<Home />} />
           <Route path="/playlists" element={<Playlists />} />
           <Route path="/playlists/:section" element={<Playlists />} />
+          <Route path="/playlists/:playlistId/:episodeId" element={<EpisodeDetail />} />
           <Route path="/seasons" element={<Seasons />} />
           <Route path="/seasons/:seasonNumber" element={<SeasonDetail />} />
+          <Route path="/seasons/:seasonNumber/episodes/:episodeNumber" element={<EpisodeDetail />} />
         </Route>
       </Routes>
     </>


### PR DESCRIPTION
# Fix the link to episode detail pages from season detail pages

Allows visitors or registered users to view a specific episode that shows more detailed information
Added `EpisodeProvider.js`
Supports the `/seasons/:season_number/:episode_number` and `/playlists/:playlistId/:episodeId` link in `ApplicationViews.js`
Added aforementioned provider to `GodProvider.js`

<!-- Add in the issue number here-->
Fixes #12 Add an 'Episode Detail' page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-episode-detail
git checkout nm-episode-detail
npm start
```

- [ ] Go to `http://localhost:3000/`
- [ ] Click 'Seasons' in the navigation bar
- [ ] Select any season
- [ ] Select any episode
- [ ] You should be able to see episode details
- [ ] Navigate to `http://localhost:3000/playlists/1/537624`
- [ ] You should be able to see episode details

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
