### PR TITLE
Fix #7 Allow any user to see a detailed view of any given playlist

### DIFF
--- a/the-enchiridion/src/components/nav/NavBar.js
+++ b/the-enchiridion/src/components/nav/NavBar.js
@@ -11,10 +11,7 @@ export const NavBar = () => {
         <Link to="/">Home</Link>
       </li>
       <li className="p-3 font-bold hover:underline decoration-wavy">
-        <Link to="/playlists">All Playlists</Link>
-      </li>
-      <li className="p-3 font-bold hover:underline decoration-wavy">
-        <Link to="/playlists/my-playlists">My Playlists</Link>
+        <Link to="/playlists">Playlists</Link>
       </li>
       <li className="p-3 font-bold hover:underline decoration-wavy">
         <Link to="/seasons">Seasons</Link>

--- a/the-enchiridion/src/components/playlists/PlaylistDetail.js
+++ b/the-enchiridion/src/components/playlists/PlaylistDetail.js
@@ -1,0 +1,45 @@
+import { useContext, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { PlaylistContext } from "./PlaylistProvider";
+
+export const PlaylistDetail = () => {
+    const { playlistId } = useParams();
+    const { getPlaylistById } = useContext(PlaylistContext);
+    const [playlist, setPlaylist] = useState({});
+    const [isLoading, setIsLoading] = useState(true);
+    const episodeimgURL = "https://www.themoviedb.org/t/p/w454_and_h254_bestv2"
+
+    useEffect(() => {
+        getPlaylistById(playlistId).then((res) => setPlaylist(res)).then(() => setIsLoading(false));
+    }, []);
+
+    if (isLoading) {
+        return <h1>Loading...</h1>;
+    } else if (playlist.message) {
+        console.log(playlist.message)
+        return <h1>Playlist not found</h1>;
+    }
+    return (
+        <>
+            <h2 className="text-3xl text-center mb-6">{playlist.name}</h2>
+            <div className="flex justify-center">
+                <div className="w-1/2 justify-start pl-4 pr-8">{playlist.description}</div>
+            </div>
+            <div>
+                {playlist.episodes.map((episode) => {
+                return (
+                    <div key={`episode--${episode.id}`} className="flex justify-center">
+                        <div className="w-1/2 justify-end pr-4 pl-8"><img src={`${episodeimgURL}${episode.still_path}`}/></div>
+                        <div className="w-1/2 justify-start pl-4 pr-8">
+                            <Link to={`${episode.id}`}>
+                                <h3 className="text-2xl">{episode.name}</h3>
+                            </Link>
+                            <p>{episode.overview}</p>
+                        </div>
+                    </div>
+                );
+                })}
+            </div>
+        </>
+    )
+}

--- a/the-enchiridion/src/components/playlists/PlaylistProvider.js
+++ b/the-enchiridion/src/components/playlists/PlaylistProvider.js
@@ -22,9 +22,13 @@ export const PlaylistProvider = (props) => {
         }).then(res => res.json())
     }
 
+    const getPlaylistById = (id) => {
+        return fetch(`${url}/playlists/${id}`).then(res => res.json())
+    }
+
     return (
         <PlaylistContext.Provider value={{
-            playlists, setPlaylists, getAllPlaylists, getUserPlaylists
+            playlists, setPlaylists, getAllPlaylists, getUserPlaylists, getPlaylistById
         }}>
             {props.children}
         </PlaylistContext.Provider>

--- a/the-enchiridion/src/components/playlists/Playlists.js
+++ b/the-enchiridion/src/components/playlists/Playlists.js
@@ -4,17 +4,34 @@ import { PlaylistContext } from './PlaylistProvider';
 
 export const Playlists = () => {
     const { playlists, setPlaylists, getAllPlaylists, getUserPlaylists } = useContext(PlaylistContext)
-    const { section } = useParams()
     const [isLoading, setIsLoading] = useState(true)
+    const [filterToggle, setFilterToggle] = useState(false)
     const navigate = useNavigate()
+    const currentUser = JSON.parse(localStorage.getItem("enchiridion_user"))
 
     useEffect(() => {
-        if (section === "my-playlists") {
+        getAllPlaylists().then((res) => setPlaylists(res)).then(() => setIsLoading(false))
+    }, [])
+
+    useEffect(() => {
+        if (filterToggle) {
             getUserPlaylists().then((res) => setPlaylists(res)).then(() => setIsLoading(false))
         } else {
             getAllPlaylists().then((res) => setPlaylists(res)).then(() => setIsLoading(false))
         }
-    }, [section])
+    }, [filterToggle])
+
+    const myPlaylistsButton = () => {
+        if (currentUser) {
+            return <button onClick={(e) => {
+                e.preventDefault()
+                setIsLoading(true)
+                setFilterToggle(!filterToggle)
+            }}>
+                {filterToggle ? "All Playlists" : "My Playlists"}
+            </button>
+        }
+    }
 
     if (isLoading) {
         return <h1>Loading...</h1>
@@ -25,6 +42,7 @@ export const Playlists = () => {
         <>
             <h1>Playlists</h1>
             <button onClick={() => navigate("/playlists/create")}>Create Playlist</button>
+            {myPlaylistsButton()}
             <ul>
                 {playlists.map(playlist => {
                     return <li key={playlist.id}><Link to={`/playlists/${playlist.id}`}>{playlist.name}</Link></li>

--- a/the-enchiridion/src/components/views/ApplicationViews.js
+++ b/the-enchiridion/src/components/views/ApplicationViews.js
@@ -1,6 +1,7 @@
 import { Outlet, Route, Routes } from "react-router-dom";
 import { Home } from "../home/Home";
 import { Playlists } from "../playlists/Playlists";
+import { PlaylistDetail } from "../playlists/PlaylistDetail";
 import { Seasons } from "../seasons/Seasons";
 import { SeasonDetail } from "../seasons/SeasonDetail";
 import { EpisodeDetail } from "../episodes/EpisodeDetail";
@@ -14,12 +15,12 @@ export const ApplicationViews = () => {
       <Routes>
         <Route path="/" element={<Outlet />}>
           <Route path="/" element={<Home />} />
-          <Route path="/playlists" element={<Playlists />} />
-          <Route path="/playlists/:section" element={<Playlists />} />
           <Route path="/playlists/:playlistId/:episodeId" element={<EpisodeDetail />} />
-          <Route path="/seasons" element={<Seasons />} />
-          <Route path="/seasons/:seasonNumber" element={<SeasonDetail />} />
+          <Route path="/playlists/:playlistId" element={<PlaylistDetail />} />
+          <Route path="/playlists" element={<Playlists />} />
           <Route path="/seasons/:seasonNumber/episodes/:episodeNumber" element={<EpisodeDetail />} />
+          <Route path="/seasons/:seasonNumber" element={<SeasonDetail />} />
+          <Route path="/seasons" element={<Seasons />} />
         </Route>
       </Routes>
     </>


### PR DESCRIPTION
# Fix the link to view the details of any playlist and display each episode

Allows visitors or registered users to view a specific playlist that shows more detailed information and list of episodes in said playlist
Added a `getPlaylistById` function to `PlaylistProvider.js`
Supports the `/playlists/:playlistId` link and removes the `/playlists/:section` link in `ApplicationViews.js` as they were conflicting with each other in testing
Added a `MyPlaylistButton` function to `Playlists.js` that only displays when a user is logged in, which incidentally fixes #8 as well
Changes the `All Playlists` link to just `Playlists` and removes `My Playlists` link from `NavBar.js`


<!-- Add in the issue number here-->
Fixes #7 Allow any user to see a detailed view of any given playlist

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-playlist-detail
git checkout nm-playlist-detail
npm start
```

- [ ] Go to `http://localhost:3000/`
- [ ] Click 'Playlists' in the navigation bar
- [ ] Select any playlist
- [ ] You should be able to see the list of episodes and the playlist description

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
