### PR TITLE
Fix #5 Allow a logged in user to create a new playlist

### DIFF
--- a/the-enchiridion/src/components/playlists/PlaylistForm.js
+++ b/the-enchiridion/src/components/playlists/PlaylistForm.js
@@ -1,0 +1,127 @@
+import { useContext, useEffect, useState } from "react"
+import { Link, useParams } from "react-router-dom"
+import { PlaylistContext } from "./PlaylistProvider"
+import { SeasonContext } from "../seasons/SeasonProvider"
+
+export const PlaylistForm = () => {
+    const [playlist, setPlaylist] = useState({
+        name: "Test Playlist 2",
+        description: "This is a test",
+        episodes: []
+    })
+    const { createPlaylist } = useContext(PlaylistContext)
+    const { seasons, setSeasons, getAllSeasons, getSeasonBySeasonNumber } = useContext(SeasonContext)
+    const [season, setSeason] = useState({
+        id: 0,
+        episodes: []
+    })
+    const [seasonNumber, setSeasonNumber] = useState(null)
+    const [episodes, setEpisodes] = useState([])
+    const [isLoading, setIsLoading] = useState(true)
+
+    useEffect(() => {
+        getAllSeasons()
+            .then((res) => setSeasons(res))
+            .then(() => setIsLoading(false))
+    }
+    , [])
+
+    useEffect(() => {
+        console.log(seasonNumber)
+        if (seasonNumber !== null) {
+            getSeasonBySeasonNumber(seasonNumber).then((res) => {
+                setSeason(res)
+                res.episodes.map(episode => episode.series_id = 15260)
+                setEpisodes(res.episodes)
+            })
+        }
+    }, [seasonNumber])
+
+    const handleControlledInputChange = (event) => {
+        const newPlaylist = { ...playlist }
+        newPlaylist[event.target.id] = event.target.value
+        setPlaylist(newPlaylist)
+    }
+
+    const handleAddEpisode = (event) => {
+        const newPlaylist = { ...playlist }
+        const selectedEpisode = episodes.find(episode => episode.id === parseInt(event.target.value))
+        selectedEpisode.order_number = newPlaylist.episodes.length + 1
+        newPlaylist.episodes.push(selectedEpisode)
+        setPlaylist(newPlaylist)
+    }
+
+    const handleRemoveEpisode = (event) => {
+        const newPlaylist = { ...playlist }
+        const episodeIndex = newPlaylist.episodes.findIndex(episode => episode.id === parseInt(event.target.value))
+        newPlaylist.episodes.splice(episodeIndex, 1)
+        setPlaylist(newPlaylist)
+    }
+
+    const handleSavePlaylist = (event) => {
+        event.preventDefault()
+        setIsLoading(true)
+        createPlaylist(playlist).then(() => {
+            setPlaylist({
+                name: "",
+                description: "",
+                episodes: []
+            })
+            setIsLoading(false)
+        })
+    }
+
+    if (isLoading) {
+        return <h1>Loading...</h1>
+    }
+    return (
+        <>
+            <h1>Create Playlist</h1>
+            <form>
+                <fieldset>
+                    <label htmlFor="name">Name:</label>
+                    <input type="text" id="name" value={playlist.name} onChange={handleControlledInputChange} />
+                </fieldset>
+                <fieldset>
+                    <label htmlFor="description">Description:</label>
+                    <input type="text" id="description" value={playlist.description} onChange={handleControlledInputChange} />
+                </fieldset>
+                <fieldset>
+                    <label htmlFor="season">Season:</label>
+                    <select id="season" onChange={(event) => {
+                        const selectedSeason = seasons.find(season => season.id === parseInt(event.target.value))
+                        setSeasonNumber(selectedSeason.season_number)
+                    }
+                    }>
+                        <option value="0">Select a season</option>
+                        {seasons.map(season => {
+                            return <option key={season.id} value={season.id}>{season.name}</option>
+                        }
+                        )}
+                    </select>
+                </fieldset>
+                <fieldset>
+                    <label htmlFor="episode">Episode:</label>
+                    <select id="episode" onChange={handleAddEpisode}>
+                        <option value="0">Select an episode</option>
+                        {episodes?.map(episode => {
+                            return <option key={episode.id} value={episode.id}>{episode.name}</option>
+                        }
+                        )}
+                    </select>
+                </fieldset>
+                <fieldset>
+                    <ol>
+                        {playlist.episodes
+                            .sort(episode => episode.order_number)
+                            .map(episode => {
+                                return <li key={episode.id}><button value={episode.id} onClick={handleRemoveEpisode}>Remove</button>Season {episode.season_number} Episode {episode.episode_number} {episode.name}</li>
+                            }
+                        )}
+                    </ol>
+                </fieldset>
+                <button onClick={handleSavePlaylist}>Save Playlist</button>
+            </form>
+        </>
+    )
+}

--- a/the-enchiridion/src/components/playlists/PlaylistProvider.js
+++ b/the-enchiridion/src/components/playlists/PlaylistProvider.js
@@ -26,9 +26,20 @@ export const PlaylistProvider = (props) => {
         return fetch(`${url}/playlists/${id}`).then(res => res.json())
     }
 
+    const createPlaylist = (playlist) => {
+        return fetch(`${url}/user-playlists`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Token ${currentUser.token}`
+            },
+            body: JSON.stringify(playlist)
+        }).then(res => res.json())
+    }
+
     return (
         <PlaylistContext.Provider value={{
-            playlists, setPlaylists, getAllPlaylists, getUserPlaylists, getPlaylistById
+            playlists, setPlaylists, getAllPlaylists, getUserPlaylists, getPlaylistById, createPlaylist
         }}>
             {props.children}
         </PlaylistContext.Provider>

--- a/the-enchiridion/src/components/playlists/Playlists.js
+++ b/the-enchiridion/src/components/playlists/Playlists.js
@@ -21,6 +21,12 @@ export const Playlists = () => {
         }
     }, [filterToggle])
 
+    const createPlaylistButton = () => {
+        if (currentUser) {
+            return <button onClick={() => navigate("/playlists/create")}>Create Playlist</button>
+        }
+    }
+
     const myPlaylistsButton = () => {
         if (currentUser) {
             return <button onClick={(e) => {
@@ -41,7 +47,7 @@ export const Playlists = () => {
     return (
         <>
             <h1>Playlists</h1>
-            <button onClick={() => navigate("/playlists/create")}>Create Playlist</button>
+            {createPlaylistButton()}
             {myPlaylistsButton()}
             <ul>
                 {playlists.map(playlist => {

--- a/the-enchiridion/src/components/views/ApplicationViews.js
+++ b/the-enchiridion/src/components/views/ApplicationViews.js
@@ -2,6 +2,7 @@ import { Outlet, Route, Routes } from "react-router-dom";
 import { Home } from "../home/Home";
 import { Playlists } from "../playlists/Playlists";
 import { PlaylistDetail } from "../playlists/PlaylistDetail";
+import { PlaylistForm } from "../playlists/PlaylistForm";
 import { Seasons } from "../seasons/Seasons";
 import { SeasonDetail } from "../seasons/SeasonDetail";
 import { EpisodeDetail } from "../episodes/EpisodeDetail";
@@ -18,6 +19,7 @@ export const ApplicationViews = () => {
           <Route path="/playlists/:playlistId/:episodeId" element={<EpisodeDetail />} />
           <Route path="/playlists/:playlistId" element={<PlaylistDetail />} />
           <Route path="/playlists" element={<Playlists />} />
+          <Route path="/playlists/create" element={<PlaylistForm />} />
           <Route path="/seasons/:seasonNumber/episodes/:episodeNumber" element={<EpisodeDetail />} />
           <Route path="/seasons/:seasonNumber" element={<SeasonDetail />} />
           <Route path="/seasons" element={<Seasons />} />


### PR DESCRIPTION
# Registered users can now create playlists

Allows registered users to create new playlists
Added a `createPlaylist` function to `PlaylistProvider.js`
Supports the `/playlists/create` link in `ApplicationViews.js`
Added a `CreatePlaylistButton` function to `Playlists.js` that only displays when a user is logged in, which incidentally fixes #18 as well
Added `PlaylistForm.js`


<!-- Add in the issue number here-->
Fixes #5 Allow a logged in user to create a new playlist

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-creating-playlists
git checkout nm-creating-playlists
npm start
```

- [ ] Go to `http://localhost:3000/`
- [ ] Make sure you're logged in (you can use username `mooglyg` and password `password`)
- [ ] Click 'Playlists' in the navigation bar
- [ ] Select the `Create Playlist` button
- [ ] Create a playlist
- [ ] Navigate back to 'Playlists' and you should see your new playlist

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
