### PR TITLE
Fix #21 Allow users to delete one of their own playlists

### DIFF
--- a/the-enchiridion/src/components/playlists/PlaylistDetail.js
+++ b/the-enchiridion/src/components/playlists/PlaylistDetail.js
@@ -4,7 +4,7 @@ import { PlaylistContext } from "./PlaylistProvider";
 
 export const PlaylistDetail = () => {
     const { playlistId } = useParams();
-    const { getPlaylistById } = useContext(PlaylistContext);
+    const { getPlaylistById, deletePlaylist } = useContext(PlaylistContext);
     const [playlist, setPlaylist] = useState({});
     const [isLoading, setIsLoading] = useState(true);
     const episodeimgURL = "https://www.themoviedb.org/t/p/w454_and_h254_bestv2"
@@ -12,7 +12,6 @@ export const PlaylistDetail = () => {
 
     useEffect(() => {
         getPlaylistById(playlistId).then((res) => setPlaylist(res)).then(() => setIsLoading(false));
-        console.log(playlist)
     }, []);
 
     const editPlaylistButton = () => {
@@ -21,6 +20,21 @@ export const PlaylistDetail = () => {
             return (
                 <button onClick={() => navigate(`/playlists/${playlistId}/edit`)}>
                     Edit Playlist
+                </button>
+            );
+        }
+    };
+
+    const deletePlaylistButton = () => {
+        const currentUser = JSON.parse(localStorage.getItem("enchiridion_user"));
+        if (playlist.user_id === currentUser.id) {
+            return (
+                <button
+                    onClick={() => {
+                        deletePlaylist(playlistId).then(() => navigate("/playlists"));
+                    }}
+                >
+                    Delete Playlist
                 </button>
             );
         }
@@ -39,6 +53,7 @@ export const PlaylistDetail = () => {
                 <div className="w-1/2 justify-start pl-4 pr-8">{playlist.description}</div>
             </div>
             {editPlaylistButton()}
+            {deletePlaylistButton()}
             <div>
                 {playlist.episodes.map((episode) => {
                 return (

--- a/the-enchiridion/src/components/playlists/PlaylistProvider.js
+++ b/the-enchiridion/src/components/playlists/PlaylistProvider.js
@@ -48,9 +48,18 @@ export const PlaylistProvider = (props) => {
         }).then(res => res.json())
     }
 
+    const deletePlaylist = (id) => {
+        return fetch(`${url}/user-playlists/${id}`, {
+            method: "DELETE",
+            headers: {
+                "Authorization": `Token ${currentUser.token}`
+            }
+        })
+    }
+
     return (
         <PlaylistContext.Provider value={{
-            playlists, setPlaylists, getAllPlaylists, getUserPlaylists, getPlaylistById, createPlaylist, updatePlaylist
+            playlists, setPlaylists, getAllPlaylists, getUserPlaylists, getPlaylistById, createPlaylist, updatePlaylist, deletePlaylist
         }}>
             {props.children}
         </PlaylistContext.Provider>


### PR DESCRIPTION
# Logged in users can now delete one of their own playlists

Allows logged in user to delete their own playlists
Adds the `deletePlaylist` function to `PlaylistProvider.js`
Adds a `deletePlaylistButton` to `PlaylistDetail.js` that checks if the currently logged in user is also the owner of the current playlist being viewed and if so displays a button that sends a delete request and then navigates the user to the list of playlists

<!-- Add in the issue number here-->
Fixes #21 Allow users to delete one of their own playlists

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-deleting-playlists
git checkout nm-deleting-playlists
npm start
```

- [ ] Go to `http://localhost:3000/`
- [ ] Make sure you're logged out
- [ ] Go to `http://localhost:3000/login`
- [ ] Register a new user
- [ ] Click 'Playlists' in the navigation bar
- [ ] Go to `http://localhost:3000/playlists/1`
- [ ] You shouldn't be able to see the `Delete Playlist` button
- [ ] Go back to viewing all playlists
- [ ] Create a new playlist
- [ ] Go to the playlist you just created
- [ ] Click `Delete Playlist`
- [ ] The playlist you just created should be gone

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
