### PR TITLE
Added logic to reduce fetches for searches and error conditions

### DIFF
--- a/the-enchiridion/public/output.css
+++ b/the-enchiridion/public/output.css
@@ -1852,12 +1852,12 @@ html {
   border-radius: 0.5rem;
 }
 
-.rounded-sm {
-  border-radius: 0.125rem;
-}
-
 .rounded-md {
   border-radius: 0.375rem;
+}
+
+.rounded-sm {
+  border-radius: 0.125rem;
 }
 
 .border {
@@ -1993,6 +1993,11 @@ html {
   color: rgb(0 0 0 / var(--tw-text-opacity));
 }
 
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgb(59 130 246 / var(--tw-text-opacity));
+}
+
 .text-gray-200 {
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity));
@@ -2122,6 +2127,11 @@ code {
 .hover\:bg-red-500:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+}
+
+.hover\:text-blue-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
 .hover\:text-white:hover {

--- a/the-enchiridion/src/components/episodes/EpisodeDetail.js
+++ b/the-enchiridion/src/components/episodes/EpisodeDetail.js
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { EpisodeContext } from "./EpisodeProvider";
 import { Loading } from "../svgs/Loading.js";
 
@@ -22,17 +22,22 @@ export const EpisodeDetail = () => {
         return <Loading />;
     } else if (episode.error) {
         console.log(episode.error)
-        return <h1>Episode not found</h1>;
+        return (
+          <div className="text-center">
+            <h1 className="text-xl md:text-2xl">TMDB failed to respond</h1>
+            <Link to={`/search/${resultId}/season/${seasonNumber}`} className="text-blue-500 hover:text-blue-700">Back to season {seasonNumber}</Link>
+          </div>
+        );
     }
     return <>
         <div>
-            <h2 className="mt-4 text-3xl text-center">{episode.name}</h2>
+            <h2 className="mt-4 text-3xl text-center">{episode?.name}</h2>
             <div className="flex justify-center mt-4">
-                <div className="w-1/2 pr-4 pl-8"><img src={`${episodeimgURL}${episode.still_path}`}/></div>
+                <div className="w-1/2 pr-4 pl-8"><img src={`${episodeimgURL}${episode?.still_path}`}/></div>
                 <div className="w-1/2 flex-col justify-start pl-4 pr-8">
                     <div>{episode.overview}</div>
-                    <div className="mt-4">Air Date: {episode.air_date}</div>
-                    <div className="mt-4">Runtime: {episode.runtime} minutes</div>
+                    <div className="mt-4">Air Date: {episode?.air_date}</div>
+                    <div className="mt-4">Runtime: {episode?.runtime} minutes</div>
                 </div>
             </div>
         </div>

--- a/the-enchiridion/src/components/playlists/PlaylistForm.js
+++ b/the-enchiridion/src/components/playlists/PlaylistForm.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, Fragment } from "react"
+import { useContext, useEffect, useState, useCallback } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { PlaylistContext } from "./PlaylistProvider"
 import { SeasonContext } from "../seasons/SeasonProvider"
@@ -202,6 +202,23 @@ export const PlaylistForm = () => {
     }
   };
 
+  // Debounce function for search
+  function debounce(func, delay) {
+    let debounceTimer;
+    return function() {
+      const context = this;
+      const args = arguments;
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => func.apply(context, args), delay);
+    }
+  }
+
+  // Debounce search
+  const debouncedSearch = useCallback(
+    debounce((e) => setSearchTerm(e.target.value), 500),
+    [],
+  )
+
   return (
     <>
       <main>
@@ -265,7 +282,7 @@ export const PlaylistForm = () => {
                   onChange={(event) => {
                     setDisplaySeasonSelect(false);
                     setDisplayEpisodeSelect(false);
-                    setSearchTerm(event.target.value);
+                    debouncedSearch(event);
                     setDisplayShowSelect(true);
                   }}
                 />

--- a/the-enchiridion/src/components/search/SearchDetail.js
+++ b/the-enchiridion/src/components/search/SearchDetail.js
@@ -34,6 +34,14 @@ export const SearchDetail = () => {
 
     if (isLoading) {
         return <Loading />
+    } else if (result.error) {
+        console.log(result.error)
+        return (
+            <div className="mx-2 my-4">
+                <h1 className="text-xl md:text-2xl">TMDB failed to respond</h1>
+                <Link to="/search" className="text-blue-500 hover:text-blue-700">Back to search</Link>
+            </div>
+        )
     }
     return (
         <div className="mx-2 my-4">

--- a/the-enchiridion/src/components/seasons/SeasonDetail.js
+++ b/the-enchiridion/src/components/seasons/SeasonDetail.js
@@ -17,8 +17,14 @@ export const SeasonDetail = () => {
 
     if (isLoading) {
         return <Loading />
-    } else if (season.detail === "Not found.") {
-        return <h1>Season not found</h1>
+    } else if (season.error) {
+        console.log(season.error)
+        return (
+            <div className="mx-2 my-4">
+                <h1 className="text-xl md:text-2xl">TMDB failed to respond</h1>
+                <Link to="/search" className="text-blue-500 hover:text-blue-700">Back to search</Link>
+            </div>
+        )
     }
     return (
         <>


### PR DESCRIPTION
# Minor updates to conditional rendering for errors, delaying fetches for live search

Added conditional rendering to pages for when TMDB is down, specifically `SearchDetail.js`, `SeasonDetail.js`, and `EpisodeDetail.js` because yesterday, it was returning a 500 server response and an internal status code of 11, which just says to contact TMDB. I went digging through forums and came up empty handed as to what the issue could be.

Oddly enough, I was checking the stats of my TMDB account and saw that there were 3 unique users at times recently (at most there should be 2 because of my desktop and laptop that I was developing this project on). I changed my API key just in case. I wasn't able to confirm this, but I also wondered if I missed a 403 rate limiting response from TMDB. I didn't get any confirmation from documentation or forums, but perhaps there is a probationary cooldown period for users that hit the rate limit where one's rate of requests is severely limited. This would explain the odd behavior I was experiencing. Here are some examples of the issues I was running into:
- Search show, broken page
- Search show, click result, broken page
- Search show, click result, click season, broken page
- Search show, click result, click season, click episode, broken page (this one happened nearly every single time)

I hadn't changed anything about how my episodes or most other specific resources were being fetched from TMDB in a while, but I quadruple checked my server side code. Ultimately, the whole thing threw me for a loop I ended up deleting my TMDB account and creating a new one. I created a new key and tried again and was still getting the same issues. Frustrated, I called it quits for the day and logged the bug as an issue for the server repo to track down later.

**This morning, everything was working perfectly! Amazing.**

In an effort to combat running into any rate limiting issues with live search, which is a feature I really like, I added a debounce function to `SearchBar.js` and `PlaylistForm.js` that delays fetching the search results until 0.5 seconds after the user has stopped typing into the search bar.

### Minor changes:
- Added error message for TMDB failing to respond to `EpisodeDetail.js`.
- Yesterday I experimented with using useNavigate when viewing an episode that TMDB failed to respond with in order to go back to the season detailed view like on some websites, and discovered a new bug #41. Leaving it in for now as it doesn't appear to be the cause of the bug necessarily.
- Added error message for TMDB failing to respond to `SeasonDetail.js` and useNavigate link back to Search component
- Added error message for TMDB failing to respond to `SearchDetail.js` and useNavigate link back to Search component
- Added error message for TMDB failing to respond to `SearchBar.js` and added debounce function I found online to stop the client from sending a request for search results after each keystroke
- Added the same debounce function to `PlaylistForm.js`

### Bug fixes:
<!-- Add in the issue number here-->
Fixes #40 Bug: Add error handling to SearchDetail and SeasonDetail when TMDB is slow to respond

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README.

```
git fetch origin nm-searching-shows
git checkout nm-searching-shows
npm start
```

- [ ] Go to `http://localhost:3000/`
- [ ] Make sure you're logged out
- [ ] Click `Search Shows` in the nav
- [ ] Search through shows, notice the timing after which the results will appear
- [ ] Click on a show
- [ ] Click on a season
- [ ] Click on an episode title
- [ ] Should TMDB fail to respond for any of those, a message should be displayed instead of the site being broken
- [ ] Go to playlists and create or edit a playlist
- [ ] Test the delayed search in there as well

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
