### PR TITLE
final config changes to dockerfile and jenkinsfile.docker for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build stage 
+# Build stage
 FROM node:latest as build
 WORKDIR /app
 COPY the-enchiridion/package*.json ./

--- a/Jenkinsfile.docker
+++ b/Jenkinsfile.docker
@@ -41,7 +41,7 @@ pipeline {
             }
             steps {
                 script {
-                    def app = docker.build("${IMAGE_NAME}:${IMAGE_TAG}")
+                    sh "docker build -t ${IMAGE_NAME}:${IMAGE_TAG} -t ${IMAGE_NAME}:latest ."
                 }
             }
         }


### PR DESCRIPTION
# Finally getting Jenkins to build Docker images only when necessary now

After a lot of trial and error, I finally got Jenkins to build a new Docker image when changes are pushed to `main`. In theory, this should only happen when a dependency in `package.json` or the `Dockerfile` itself is modified, but this has yet to be tested (next commit and push).

- Modified tags in `Jenkinsfile.docker` to allow a future `Jenkinsfile` to pull the most recent image from the Docker Hub repository so that the website always has any needed dependencies installed when containerized.
- Removed an extraneous space in the `Dockerfile` to trigger a new build. Next push will be a modification to any part of the code aside from the aforementioned `Dockerfile` and `package.json` to ensure a new Docker image isn't built and pushed to Docker Hub.

### Bug fixes:
None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README.

```
git fetch origin nm-cicd
git checkout nm-cicd
npm start
```

- [ ] It just works.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes