### PR TITLE
Implementing likes functionality

### DIFF
--- a/the-enchiridion/src/components/home/Home.js
+++ b/the-enchiridion/src/components/home/Home.js
@@ -13,14 +13,10 @@ export const Home = () => {
   useEffect(() => {
     getAllPlaylists()
       .then((res) => setPlaylists(res))
-      .then(() => {
-        setTimeout(() => setIsLoading(false), 500);
-      });
+      .then(() => setIsLoading(false));
     getTrendingPlaylists(7)
       .then((res) => setTrendingPlaylists(res))
-      .then(() => {
-        setTimeout(() => setIsLoading(false), 500);
-      });
+      .then(() => setIsLoading(false));
   }, []);
 
   if (isLoading) {

--- a/the-enchiridion/src/components/home/Home.js
+++ b/the-enchiridion/src/components/home/Home.js
@@ -1,14 +1,17 @@
 import { useState, useContext, useEffect } from "react";
-import { useScreenSize } from "../../utils/useScreenSize.js";
+import { useSelector, useDispatch } from "react-redux";
 import { PlaylistContext } from "../../providers/PlaylistProvider.js";
 import { PlaylistCard } from "../playlists/PlaylistCard";
 import { Loading } from "../svgs/Loading.js";
+import { trigger } from "../../redux/actions/utilityActions.js";
 
 export const Home = () => {
   const { playlists, setPlaylists, getAllPlaylists, getTrendingPlaylists } =
     useContext(PlaylistContext);
   const [trendingPlaylists, setTrendingPlaylists] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const triggerState = useSelector((state) => state.utility.trigger);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     getAllPlaylists()
@@ -18,6 +21,16 @@ export const Home = () => {
       .then((res) => setTrendingPlaylists(res))
       .then(() => setIsLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (triggerState === "update") {
+      getAllPlaylists()
+        .then((res) => setPlaylists(res))
+      getTrendingPlaylists(7)
+        .then((res) => setTrendingPlaylists(res))
+      dispatch(trigger(null))
+    }
+  }, [triggerState]);
 
   if (isLoading) {
     // Spinning wheel loading animation

--- a/the-enchiridion/src/components/playlists/PlaylistCard.js
+++ b/the-enchiridion/src/components/playlists/PlaylistCard.js
@@ -1,13 +1,20 @@
-import React from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useScreenSize } from "../../utils/useScreenSize";
 import { makePlaylistImage } from "../../utils/makePlaylistImage.js";
 import { LikeIcon } from "../svgs/LikeIcon";
+import { PlaylistContext } from "../../providers/PlaylistProvider.js";
+import { useSelector, useDispatch } from "react-redux";
+import { showSnackbar } from "../../redux/actions/snackbarActions";
 
 export const PlaylistCard = ({ playlist }) => {
+  const { likePlaylist, unlikePlaylist } = useContext(PlaylistContext)
   const { isMobile } = useScreenSize();
   const episodeCount = playlist.episodes.length;
   const playlistImage = makePlaylistImage(playlist);
+  const currentUser = useSelector((state) => state.auth.userData);
+  const [likesCount, setLikesCount] = useState(playlist.likes_count);
+  const dispatch = useDispatch();
 
   const calculateTotalRuntime = (episodes) => {
     const totalRunTimeMins = episodes.reduce((runtimeAccumulator, episode) => {
@@ -18,13 +25,40 @@ export const PlaylistCard = ({ playlist }) => {
     return `${hours}h ${minutes}m`;
   };
 
+  const handleLike = (playlist) =>  {
+    if (!currentUser.id) {
+      dispatch(showSnackbar("You must be logged in", "error"))
+    }
+    else {
+      if (playlist.is_liked) {
+        unlikePlaylist(playlist.id)
+        setLikesCount(likesCount - 1)
+        playlist.likes_count = likesCount - 1;
+        playlist.is_liked = false
+        return playlist
+      }
+      else {
+        likePlaylist(playlist.id)
+        setLikesCount(likesCount + 1)
+        playlist.likes_count = likesCount + 1;
+        playlist.is_liked = true
+        return playlist
+      }
+    }
+  }
+
+  useEffect(() => {
+    setLikesCount(playlist.likes_count);
+  }, [playlist.likes_count]);
+
   return (
     <div className="card-playlists">
+      <div className="absolute top-0 right-2 flex">
+          <div className="h-4 mt-2 mr-1 text-sm text-gray-500">{likesCount}</div>
+          <div onClick={() => handleLike(playlist)} className="mt-2"><LikeIcon fill={playlist.is_liked ? "rgb(107 114 128)" : "rgb(156 163 175)" }/></div>
+      </div>
       <Link to={`/playlists/${playlist.id}`}>
-        <div className="absolute top-0 right-2 flex">
-          <div className="h-4 mt-2 mr-1 text-sm text-gray-500">{playlist.likes_count}</div>
-          <div className="mt-2"><LikeIcon fill="rgb(107 114 128)"/></div>
-        </div>
+        
         <div className="my-3">{playlistImage}</div>
         <div>
           <div className="my-2 text-lg md:text-xl text-center">{playlist.name}</div>
@@ -38,7 +72,7 @@ export const PlaylistCard = ({ playlist }) => {
             </div>
           )}
         </div>
-        <div className="absolute bottom-0 w-full my-2 text-xs text-center text-gray-500">
+        <div className="absolute my-2 bottom-0 left-1/2 transform -translate-x-1/2 text-xs text-center text-gray-500">
           {isMobile ? (
             <p>
               {episodeCount} eps • {calculateTotalRuntime(playlist.episodes)}

--- a/the-enchiridion/src/components/playlists/PlaylistCard.js
+++ b/the-enchiridion/src/components/playlists/PlaylistCard.js
@@ -6,6 +6,7 @@ import { LikeIcon } from "../svgs/LikeIcon";
 import { PlaylistContext } from "../../providers/PlaylistProvider.js";
 import { useSelector, useDispatch } from "react-redux";
 import { showSnackbar } from "../../redux/actions/snackbarActions";
+import { trigger } from "../../redux/actions/utilityActions.js";
 
 export const PlaylistCard = ({ playlist }) => {
   const { likePlaylist, unlikePlaylist } = useContext(PlaylistContext)
@@ -35,6 +36,7 @@ export const PlaylistCard = ({ playlist }) => {
         setLikesCount(likesCount - 1)
         playlist.likes_count = likesCount - 1;
         playlist.is_liked = false
+        dispatch(trigger("update"))
         return playlist
       }
       else {
@@ -42,6 +44,7 @@ export const PlaylistCard = ({ playlist }) => {
         setLikesCount(likesCount + 1)
         playlist.likes_count = likesCount + 1;
         playlist.is_liked = true
+        dispatch(trigger("update"))
         return playlist
       }
     }

--- a/the-enchiridion/src/providers/PlaylistProvider.js
+++ b/the-enchiridion/src/providers/PlaylistProvider.js
@@ -71,6 +71,24 @@ export const PlaylistProvider = (props) => {
     ).catch((err) => console.log(err));
   };
 
+  const likePlaylist = (playlistId) => {
+    return fetch(
+      `${url}/likes`,
+      postPutDeleteOptions("POST", 
+        {
+          playlist_id: playlistId,
+        }
+      )
+    ).catch((err) => console.log(err));
+  };
+
+  const unlikePlaylist = (playlistId) => {
+    return fetch(
+      `${url}/likes/${playlistId}`,
+      postPutDeleteOptions("DELETE")
+    ).catch((err) => console.log(err));
+  }
+
   return (
     <PlaylistContext.Provider
       value={{
@@ -83,6 +101,8 @@ export const PlaylistProvider = (props) => {
         createPlaylist,
         updatePlaylist,
         deletePlaylist,
+        likePlaylist,
+        unlikePlaylist
       }}
     >
       {props.children}

--- a/the-enchiridion/src/redux/actions/utilityActions.js
+++ b/the-enchiridion/src/redux/actions/utilityActions.js
@@ -1,0 +1,8 @@
+export const TRIGGER = 'TRIGGER';
+
+export const trigger = (payload) => {
+    return {
+        type: TRIGGER,
+        payload: payload,
+    }
+}

--- a/the-enchiridion/src/redux/reducers/index.js
+++ b/the-enchiridion/src/redux/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import { snackbarReducer } from './snackbarReducer';
 import { authReducer } from './authReducer';
+import { utilityReducer } from './utilityReducer';
 
 export const rootReducer = combineReducers({
     snackbar: snackbarReducer,
     auth: authReducer,
+    utility: utilityReducer,
 });

--- a/the-enchiridion/src/redux/reducers/utilityReducer.js
+++ b/the-enchiridion/src/redux/reducers/utilityReducer.js
@@ -1,0 +1,17 @@
+import { TRIGGER } from "../actions/utilityActions";
+
+const initialState = {
+    trigger: null,
+};
+
+export const utilityReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case TRIGGER:
+            return {
+                ...state,
+                trigger: action.payload,
+            };
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
# Users can now like their own and others' playlists

The most recent version of the backend api is now able to add the following to playlists objects:
- `is_liked`: Boolean
- `likes_count`: int

This means that we can now show likes and allow users to like and unlike playlists at will. As such, the following changes have been made:

- `/like` and `/like/:playlistId` are now valid endpoints for the api allowing the user to like/unlike the selected playlist (for the former, the playlist id is passed in the body of the POST request). `PlaylistProvider.js` has been updated accordingly.
- `PlaylistCard.js` has added a handleLike function that does a bunch of stuff, like calling a new redux action
- Created a new redux action that I'll be able to use whenever I want to broadcast stuff and have other parts of my app listen.
- Updated `Home.js` to listen for updates regarding likes
- The like icon's fill on `PlaylistCard` is dependent on the current user having liked that playlist
- Some other minor changes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README.

```
git fetch origin nm-likes
git checkout nm-likes
npm start
```

- [ ] checkout the [most recent update for the api](https://github.com/macleann/enchiridion-server) and try things out!

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes