### PR TITLE
Trying to get tests to pass in CI/CD environment

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
@@ -15,6 +15,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14
+
+      - name: Install dependencies and build
+        working-directory: the-enchiridion
+        run: |
+          npm ci
+          npm run build
+
       - name: Cypress run
         working-directory: the-enchiridion
         run: |

--- a/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
@@ -16,13 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Cypress run
-        uses: cypress-io/github-action@v6
-        with:
-          build: npm run build
-          start: npm start
-          component: true
-          working-directory: the-enchiridion
-          env: REACT_APP_GOOGLE_CLIENT_ID=${{ secrets.CYPRESS_REACT_APP_GOOGLE_CLIENT_ID }},REACT_APP_API_URL=${{ secrets.CYPRESS_REACT_APP_API_URL }},REACT_APP_URL=${{ secrets.CYPRESS_REACT_APP_URL }}
+        working-directory: the-enchiridion
+        run: |
+          REACT_APP_GOOGLE_CLIENT_ID=${{ secrets.CYPRESS_REACT_APP_GOOGLE_CLIENT_ID }},
+          REACT_APP_API_URL=${{ secrets.CYPRESS_REACT_APP_API_URL }},
+          REACT_APP_URL=${{ secrets.CYPRESS_REACT_APP_URL }}
+          npx cypress run --component
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest


### PR DESCRIPTION
So my tests are all passing locally. I have the receipts to prove it!
```
====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  auth/Login.cy.js                         00:01        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  auth/Register.cy.js                      00:04        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  episodes/EpisodeDetail.cy.js             121ms        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  episodes/Episodes.cy.js                  171ms        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  home/Home.cy.js                          133ms        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  nav/NavBar.cy.js                         640ms        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  playlists/PlaylistCard.cy.js             232ms        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  playlists/PlaylistDetail.cy.js           470ms        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  playlists/PlaylistForm.cy.js             00:07        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  search/SearchBar.cy.js                   00:01        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  search/SearchDetail.cy.js                118ms        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  seasons/SeasonDetail.cy.js               244ms        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  seasons/Seasons.cy.js                    195ms        3        3        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:17       39       39        -        -        -  
```

However, in order to do so, I've only ever managed to set my environment variables this way:
```
REACT_APP_GOOGLE_CLIENT_ID=115078931939-eoj0gcm7iail2dfu94b02nsuh9gffm7o.apps.googleusercontent.com \
REACT_APP_API_URL=http://localhost:8000 \
REACT_APP_URL=http://localhost:3000 \
npx cypress run --component
```
(Normally, I'd run `npx cypress open` locally to use Cypress' beautiful UI, but this is to illustrate that this should work in theory.) Any other way of setting environment variables results in multiple failures

So the next hurdle is that my previous way of trying to get all of my tests to pass locally don't work. I'm very certain that the issue lies in my frequent use of the `useParams` hook. A lot of my components rely on context for their requests coming from the URL as opposed to state, as I find it more finicky. Consequently, a lot of my tests have to follow the same procedure to set the URL so that's it's in a pattern expected by the code (there's a point of optimization for future endeavors). Taking the time to refactor that code seems like the larger investment of time to me.

And to confirm that this environment variable setting nonsense is the same issue as what I'm bumping my head into with implementing my CI/CD workflow here, I can confirm that I have the same 28 failures as [my most recent workflow execution here](https://github.com/macleann/enchiridion-client/actions/runs/8195222555/job/22412995968) when I simply run `npx cypress run --component` without setting the env in the way that I currently am.

That brings me finally to the changes here. It's my _hope_ that by installing and building the app, and then running the same command that I run locally, I can get this to work, but I'm not super confident. I might just have to invest the time to refactor my code.