### PR TITLE
updating node version

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install dependencies and build
         working-directory: the-enchiridion
         env:


### PR DESCRIPTION
```
TypeError: Object.hasOwn is not a function
    at Array.forEach (<anonymous>)
    at Array.forEach (<anonymous>)
```

Error encountered when running GitHub Actions workflow. Apparently ["Object.hasOwn was introduced in V8 9.3, which [was] shipped in Node v16.9.0"](https://github.com/nodejs/node/issues/41471). Updating Node version in workflow.