### PR TITLE
testing after testing locally with act

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-desert-0f1f8a110.yml
@@ -25,12 +25,6 @@ jobs:
         run: |
           npm install
           npm run build
-      - name: Debug
-        run: |
-          echo "Environment Variables:"
-          printenv
-          echo "package.json:"
-          cat package.json
       - name: Cypress run
         working-directory: the-enchiridion
         env:
@@ -38,9 +32,6 @@ jobs:
           REACT_APP_API_URL: https://api.enchiridion.tv
           REACT_APP_URL: https://enchiridion.tv
         run: |
-          REACT_APP_GOOGLE_CLIENT_ID: 115078931939-eoj0gcm7iail2dfu94b02nsuh9gffm7o.apps.googleusercontent.com
-          REACT_APP_API_URL: https://api.enchiridion.tv
-          REACT_APP_URL: https://enchiridion.tv
           npx cypress run --component
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
# Using `act` To Test GitHub Actions Locally

- I installed `act` to test GitHub Actions workflows locally so that I don't have to commit/push as much. I wish I had thought to install this earlier.
- I think I'm at a good place now. The current error I'm getting is `Your system is missing the dependency: Xvfb`, which I've been led to believe this is just a local issue and should run fine in the GitHub environment.
- See [Struggling to set up and run a basic Cypress Github Action because of Xvfb](https://github.com/cypress-io/github-action/issues/601)
- If I need to, I can try specifying the container?